### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     url='http://github.com/idlesign/django-sitemetrics',
     packages=['sitemetrics'],
     include_package_data=True,
-    install_requires=['setuptools'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Removed 'setuptools' from setup.py's 'install_requires' which is generating installation failures on complex requirements.txt.

As seen [here](https://github.com/gregmuellegger/django-mobile/pull/20) having setuptools in your install_requires is not a good idea. In my case, I have a rather long requirements.txt which passes if I remove `django-sitemetrics` and fails with an error related to setuptools when I add the line again.

The issue seems to be that when running `pip install -r requirements.txt --upgrade` pip tries to remove and then install setuptools (required by your package) and after removing it, it tries to use something from setuptools and simply fails.

Anyways, your package doesn't require setuptools to work and everything should be fine without it.
