### PR TITLE
call template.render with a dict for Django >= 1.8

### DIFF
--- a/sitemetrics/templatetags/sitemetrics.py
+++ b/sitemetrics/templatetags/sitemetrics.py
@@ -1,3 +1,4 @@
+import django
 from django import template
 from django.conf import settings
 from django.core.cache import cache
@@ -92,4 +93,7 @@ class sitemetricsNode(template.Node):
         self.template = template.loader.get_template('sitemetrics/sitemetrics.tpl')
 
     def render(self, context):
-        return self.template.render(template.Context({'keycodes': self.keycodes}))
+        context = template.Context({'keycodes': self.keycodes})
+        if django.VERSION >= (1, 8):
+            context = context.flatten()
+        return self.template.render(context)

--- a/sitemetrics/templatetags/sitemetrics.py
+++ b/sitemetrics/templatetags/sitemetrics.py
@@ -93,7 +93,7 @@ class sitemetricsNode(template.Node):
         self.template = template.loader.get_template('sitemetrics/sitemetrics.tpl')
 
     def render(self, context):
-        context = template.Context({'keycodes': self.keycodes})
-        if django.VERSION >= (1, 8):
-            context = context.flatten()
+        context = {'keycodes': self.keycodes}
+        if django.VERSION < (1, 8):
+            context = template.Context(context)
         return self.template.render(context)


### PR DESCRIPTION
small fix to prevent `RemovedInDjango110Warning: render() must be called with a dict, not a Context.`
